### PR TITLE
sorting now overwrites instead of adding more products for given sour…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "grafana_api",
 ]
 name = "trendify"
-version = "1.1.13"
+version = "1.1.14"
 requires-python = ">= 3.9"
 authors = [
   { name = "Talbot Knighton", email = "talbotknighton@gmail.org" },


### PR DESCRIPTION
Product index map improved and behavior changed.

Now metadata (source dir) is used to identify which index to be used. So, if products are processed from the same folder, they will overwrite the given index.